### PR TITLE
Child and descendant selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A path is a vector of keywords or string of hiccup-esque element selectors. Like
 
 - `[:a]` matches all anchor tags.
 - `[:form :input]` matches all input tags nested inside a form.
+- `[:form :> :input]` matches all input tags that are direct children of a form.
 - `[:div.foo]` matches all div tags with "foo" in its class name.
 - `[:.button]` matches all elements with the "button" class.
 - `[:div#content]` matches the div with "content" as its id.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ or
 
 html5-walker exposes these functions:
 
-### find-nodes
+### html5-walker.walker/find-nodes
 
 Signature: `(find-nodes html-string path)`
 
@@ -24,18 +24,18 @@ It returns a sequence of
 [Nodes](https://static.javadoc.io/ch.digitalfondue.jfiveparse/jfiveparse/0.6.0/ch/digitalfondue/jfiveparse/Node.html)
 matching the path.
 
-A path is a vector of keywords or string of hiccup-esque element selectors. Like this:
+A path is a vector of symbols (or strings) of CSS selectors. Like this:
 
-- `[:a]` matches all anchor tags.
-- `[:form :input]` matches all input tags nested inside a form.
-- `[:form :> :input]` matches all input tags that are direct children of a form.
-- `[:div.foo]` matches all div tags with "foo" in its class name.
-- `[:.button]` matches all elements with the "button" class.
-- `[:div#content]` matches the div with "content" as its id.
-- `[:first-child]` matches any element that is the first child.
-- `[:last-child]` matches any element that is the last child.
-- `["meta[property]"]` matches all meta tags with the `property` attribute.
-- `["meta[property=og:title]"]` matches all meta tags with the `property`
+- `'[a]` matches all anchor tags.
+- `'[form input]` matches all input tags nested inside a form.
+- `'[form > input]` matches all input tags that are direct children of a form.
+- `'[div.foo]` matches all div tags with "foo" in its class name.
+- `'[.button]` matches all elements with the "button" class.
+- `'[div#content]` matches the div with "content" as its id.
+- `'[first-child]` matches any element that is the first child.
+- `'[last-child]` matches any element that is the last child.
+- `'["meta[property]"]` matches all meta tags with the `property` attribute.
+- `'["meta[property=og:title]"]` matches all meta tags with the `property`
   attribute set to "og:title".
 
 The following additional attribute selectors are also supported, and work like
@@ -44,25 +44,30 @@ they do in CSS: `*=`, `$=`, `~=` and `^=`.
 So running:
 
 ```clj
-(find-nodes "<ul><li>1</li><li>2</li></ul>" [:ul :li])
+(require '[html5-walker.walker :as walker])
+
+(walker/find-nodes "<ul><li>1</li><li>2</li></ul>" '[ul li])
 ```
 
 would return a sequence with two `li` nodes in it. [See the javadoc for more
 information about these
 nodes.](https://static.javadoc.io/ch.digitalfondue.jfiveparse/jfiveparse/0.6.0/ch/digitalfondue/jfiveparse/Node.html)
 
-### replace-in-fragment
+### html5-walker.walker/replace-in-fragment
 
 Signature: `(replace-in-fragment html-string path->fn)`
 
-This returns a new html-string with any changes performed by the functions in the `path->fn` map applied.
+This returns a new html-string with any changes performed by the functions in
+the `path->fn` map applied.
 
 So running:
 
 ```clj
-(replace-in-fragment
+(require '[html5-walker.walker :as walker])
+
+(walker/replace-in-fragment
   "<ul><li>1</li><li>2</li></ul>"
-  {[:ul :li] (fn [node] (.setInnerHTML node (str (.getInnerHTML node) "!!!")))})
+  {'[ul li] (fn [node] (.setInnerHTML node (str (.getInnerHTML node) "!!!")))})
 ```
 
 would return:
@@ -71,7 +76,7 @@ would return:
 "<ul><li>1!!!</li><li>2!!!</li></ul>"
 ```
 
-### replace-in-document
+### html5-walker.walker/replace-in-document
 
 Just like `replace-in-fragment`, except it works on an entire html document.
 This means that `html`, `head` and `body` tags are expected to be there. They
@@ -82,6 +87,14 @@ Note that `replace-in-fragment` will actually remove these tags when found.
 ## More usage
 
 Take a look at the tests if you'd like more examples.
+
+## About `html5-walker.core`
+
+The `html5-walker.core` namespace contains the same three functions as above.
+These functions work exactly the same, with one important difference: `'[div a]`
+is treated as `'[div > a]`, e.g. a direct child selector. This was the library's
+original behavior, and the core namespace is kept around for backwards
+compatibility.
 
 ## Changes
 

--- a/src/html5_walker/core.clj
+++ b/src/html5_walker/core.clj
@@ -1,102 +1,34 @@
 (ns html5-walker.core
-  (:require [clojure.string :as str])
-  (:import (ch.digitalfondue.jfiveparse Element Parser Selector)))
+  (:require [html5-walker.walker :as walker])
+  (:import (ch.digitalfondue.jfiveparse Element Parser)))
 
-(def prefix->kind
-  {nil :element
-   "#" :id
-   "." :class
-   "[" :attr})
-
-(defn parse-selector
-  "Breaks a CSS selector element into tag matcher, class matchers, id matcher, and
-  attribute matchers."
-  [selector]
-  (->> (str/replace selector #":(first|last)-child" "")
-       (re-seq #"([#\.\[])?([a-z0-9\-\:]+)(?:(.?=)([a-z0-9\-\:]+)])?")
-       (map #(into [(prefix->kind (second %))] (remove nil? (drop 2 %))))
-       (concat (->> (re-seq #":((?:first|last)-child)" selector)
-                    (map (comp vector keyword second))))))
-
-(comment
-
-  (parse-selector "div#content.text[property=og:image].mobile[style][data-test~=bla]:first-child")
-  (parse-selector "div:first-child")
-  (parse-selector ":first-child")
-  (parse-selector "[property]")
-
-  )
-
-(defn- match-path-fragment [selector element]
-  (reduce
-   (fn [s [kind m comparator v]]
-     (case kind
-       :element (.element s m)
-       :id (.id s m)
-       :class (.hasClass s m)
-       :attr (case comparator
-               "=" (.attrValEq s m v)
-               "*=" (.attrValContains s m v)
-               "$=" (.attrValEndWith s m v)
-               "~=" (.attrValInList s m v)
-               "^=" (.attrValStartWith s m v)
-               nil (.attr s m))
-       :first-child (.isFirstChild s)
-       :last-child (.isLastChild s)))
-   selector
-   (parse-selector (name element))))
-
-(defn make-descendants-explicit
-  "Walks a path and returns pairs of [descendant element] where descendant is
-  either `:descendant` or `:child`, describing the desired relationship to the
-  previous path element. `descendant` will be `nil` for the first element. `:>`
-  creates a `:child` relationship between two elements, while elements that
-  don't have an explicit relationship (e.g. `[:div :a]`) will have a
-  `:descendant` interposed between them."
+(defn enforce-child-selectors
+  "Preserves the old behavior where [:div :a] enforced a child relationship."
   [path]
   (->> (partition-all 2 1 path)
-       (remove (comp #{:>} first))
+       (remove (comp #{">"} #(some-> % name) first))
        (mapcat
         (fn [[element descendant]]
-          (cond
-            (= :> descendant)
-            [element :child]
-
-            (nil? descendant)
+          (if (nil? descendant)
             [element]
-
-            :else
-            [element :descendant])))
-       (into [nil])
-       (partition 2)))
+            [element '>])))))
 
 (defn create-matcher [path]
-  (let [path (make-descendants-explicit path)]
-    (.toMatcher
-     (reduce (fn [selector [descendant element-kw]]
-               (-> (case descendant
-                     :descendant (.withDescendant selector)
-                     :child (.withChild selector))
-                   (match-path-fragment element-kw)))
-             (-> (Selector/select)
-                 (match-path-fragment (second (first path))))
-             (next path)))))
+  (walker/create-matcher (enforce-child-selectors path)))
 
-(defn replace-in-document [html path->f]
-  (let [parser (Parser.)
-        doc (.parse parser html)]
+(defn ^:export replace-in-document [html path->f]
+  (let [doc (.parse (Parser.) html)]
     (doseq [[path f] path->f]
       (doseq [node (.getAllNodesMatching doc (create-matcher path))]
         (f node)))
     (.getOuterHTML (.getDocumentElement doc))))
 
-(defn replace-in-fragment [html path->f]
-  (let [parser (Parser.)
-        el (first (.parseFragment parser (Element. "div") (str "<div>" html "</div>")))]
+(defn ^:export replace-in-fragment [html path->f]
+  (let [el (first (.parseFragment (Parser.) (Element. "div") (str "<div>" html "</div>")))]
     (doseq [[path f] path->f]
       (doseq [node (.getAllNodesMatching el (create-matcher path))]
         (f node)))
     (.getInnerHTML el)))
 
-(defn find-nodes [html path]
+(defn ^:export find-nodes [html path]
   (.getAllNodesMatching (.parse (Parser.) html) (create-matcher path)))

--- a/src/html5_walker/walker.clj
+++ b/src/html5_walker/walker.clj
@@ -1,0 +1,100 @@
+(ns html5-walker.walker
+  (:require [clojure.string :as str])
+  (:import (ch.digitalfondue.jfiveparse Element Parser Selector)))
+
+(def prefix->kind
+  {nil :element
+   "#" :id
+   "." :class
+   "[" :attr})
+
+(defn parse-selector
+  "Breaks a CSS selector element into tag matcher, class matchers, id matcher, and
+  attribute matchers."
+  [selector]
+  (->> (str/replace selector #":(first|last)-child" "")
+       (re-seq #"([#\.\[])?([a-z0-9\-\:]+)(?:(.?=)([a-z0-9\-\:]+)])?")
+       (map #(into [(prefix->kind (second %))] (remove nil? (drop 2 %))))
+       (concat (->> (re-seq #":((?:first|last)-child)" selector)
+                    (map (comp vector keyword second))))))
+
+(comment
+
+  (parse-selector "div#content.text[property=og:image].mobile[style][data-test~=bla]:first-child")
+  (parse-selector "div:first-child")
+  (parse-selector ":first-child")
+  (parse-selector "[property]")
+
+  )
+
+(defn- match-path-fragment [selector element]
+  (reduce
+   (fn [s [kind m comparator v]]
+     (case kind
+       :element (.element s m)
+       :id (.id s m)
+       :class (.hasClass s m)
+       :attr (case comparator
+               "=" (.attrValEq s m v)
+               "*=" (.attrValContains s m v)
+               "$=" (.attrValEndWith s m v)
+               "~=" (.attrValInList s m v)
+               "^=" (.attrValStartWith s m v)
+               nil (.attr s m))
+       :first-child (.isFirstChild s)
+       :last-child (.isLastChild s)))
+   selector
+   (parse-selector (name element))))
+
+(defn make-descendants-explicit
+  "Walks a path and returns pairs of [descendant element] where descendant is
+  either `:descendant` or `:child`, describing the desired relationship to the
+  previous path element. `descendant` will be `nil` for the first element. `:>`
+  creates a `:child` relationship between two elements, while elements that
+  don't have an explicit relationship (e.g. `[:div :a]`) will have a
+  `:descendant` interposed between them."
+  [path]
+  (->> (partition-all 2 1 path)
+       (remove (comp #{">"} #(some-> % name) first))
+       (mapcat
+        (fn [[element descendant]]
+          (cond
+            (nil? descendant)
+            [element]
+
+            (= ">" (name descendant))
+            [element :child]
+
+            :else
+            [element :descendant])))
+       (into [nil])
+       (partition 2)))
+
+(defn create-matcher [path]
+  (let [path (make-descendants-explicit path)]
+    (.toMatcher
+     (reduce (fn [selector [descendant element-kw]]
+               (-> (case descendant
+                     :descendant (.withDescendant selector)
+                     :child (.withChild selector))
+                   (match-path-fragment element-kw)))
+             (-> (Selector/select)
+                 (match-path-fragment (second (first path))))
+             (next path)))))
+
+(defn ^:export replace-in-document [html path->f]
+  (let [doc (.parse (Parser.) html)]
+    (doseq [[path f] path->f]
+      (doseq [node (.getAllNodesMatching doc (create-matcher path))]
+        (f node)))
+    (.getOuterHTML (.getDocumentElement doc))))
+
+(defn ^:export replace-in-fragment [html path->f]
+  (let [el (first (.parseFragment (Parser.) (Element. "div") (str "<div>" html "</div>")))]
+    (doseq [[path f] path->f]
+      (doseq [node (.getAllNodesMatching el (create-matcher path))]
+        (f node)))
+    (.getInnerHTML el)))
+
+(defn ^:export find-nodes [html path]
+  (.getAllNodesMatching (.parse (Parser.) html) (create-matcher path)))

--- a/test/html5_walker/core_test.clj
+++ b/test/html5_walker/core_test.clj
@@ -33,12 +33,12 @@
                  [:a.foo.baz]))
            ["fool"])))
 
-  (testing "descendant selector"
+  (testing "implicit child selector"
     (is (= (map #(.getAttribute % "href")
                 (sut/find-nodes
                  "<body>Hello!
                   <div class=\"foo\"><a href=\"fool\">Hi!</a></div>
-                  <div class=\"bar\"><div><a href=\"barn\">Howdy!</a></div></div>
+                  <div class=\"bar\"><a href=\"barn\">Howdy!</a></div>
                 </body>"
                  [:div.bar :a]))
            ["barn"])))
@@ -53,14 +53,14 @@
                  [:div.bar :> :a]))
            [])))
 
-  (testing "child selector"
+  (testing "explicit child selector"
     (is (= (map #(.getAttribute % "href")
                 (sut/find-nodes
                  "<body>Hello!
                   <div class=\"foo\"><a href=\"fool\">Hi!</a></div>
                   <div class=\"bar\"><div><a href=\"barn\">Howdy!</a></div></div>
                 </body>"
-                 [:div.bar :> :div :> :a]))
+                 '[div.bar > div > a]))
            ["barn"])))
 
   (testing ".class only selector"

--- a/test/html5_walker/core_test.clj
+++ b/test/html5_walker/core_test.clj
@@ -38,9 +38,29 @@
                 (sut/find-nodes
                  "<body>Hello!
                   <div class=\"foo\"><a href=\"fool\">Hi!</a></div>
-                  <div class=\"bar\"><a href=\"barn\">Howdy!</a></div>
+                  <div class=\"bar\"><div><a href=\"barn\">Howdy!</a></div></div>
                 </body>"
                  [:div.bar :a]))
+           ["barn"])))
+
+  (testing "child selector does not match any descendant"
+    (is (= (map #(.getAttribute % "href")
+                (sut/find-nodes
+                 "<body>Hello!
+                  <div class=\"foo\"><a href=\"fool\">Hi!</a></div>
+                  <div class=\"bar\"><div><a href=\"barn\">Howdy!</a></div></div>
+                </body>"
+                 [:div.bar :> :a]))
+           [])))
+
+  (testing "child selector"
+    (is (= (map #(.getAttribute % "href")
+                (sut/find-nodes
+                 "<body>Hello!
+                  <div class=\"foo\"><a href=\"fool\">Hi!</a></div>
+                  <div class=\"bar\"><div><a href=\"barn\">Howdy!</a></div></div>
+                </body>"
+                 [:div.bar :> :div :> :a]))
            ["barn"])))
 
   (testing ".class only selector"

--- a/test/html5_walker/walker_test.clj
+++ b/test/html5_walker/walker_test.clj
@@ -1,0 +1,34 @@
+(ns html5-walker.walker-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [html5-walker.walker :as sut]))
+
+(deftest selector-test
+  (testing "implicit descendant selector"
+    (is (= (map #(.getAttribute % "href")
+                (sut/find-nodes
+                 "<body>Hello!
+                    <div class=\"foo\"><a href=\"fool\">Hi!</a></div>
+                    <div class=\"bar\"><div><a href=\"barn\">Howdy!</a></div></div>
+                  </body>"
+                 '[div.bar a]))
+           ["barn"])))
+
+  (testing "child selector does not match any descendant"
+    (is (= (map #(.getAttribute % "href")
+                (sut/find-nodes
+                 "<body>Hello!
+                    <div class=\"foo\"><a href=\"fool\">Hi!</a></div>
+                    <div class=\"bar\"><div><a href=\"barn\">Howdy!</a></div></div>
+                  </body>"
+                 '[div.bar > a]))
+           [])))
+
+  (testing "explicit child selector"
+    (is (= (map #(.getAttribute % "href")
+                (sut/find-nodes
+                 "<body>Hello!
+                    <div class=\"foo\"><a href=\"fool\">Hi!</a></div>
+                    <div class=\"bar\"><div><a href=\"barn\">Howdy!</a></div></div>
+                  </body>"
+                 '[div.bar > div > a]))
+           ["barn"]))))


### PR DESCRIPTION
This pull request is based on the work in #2. This one allows you to distinguish between descendant selectors and direct children:

```clojure
[:div :a] ;; Descendant selector, e.g. "any a under a div"
[:div :> :a] ;; Children selector, e.g. "any a directly child to a div"
```

This is technically a breaking change, as the current implementation could be considered buggy - it considers `[:div :a]` to be a direct child selector. This breaks with expectations if you're familiar with CSS, but changing it could change the behavior of existing code... Not sure what the best way to approach this is, but at the very least it would be good to have support for descendant selectors.

My gut feeling is that this change - while breaking - is ok, since my guess is that people are already using selectors expecting this "new" behavior. But I'm not sure.